### PR TITLE
Minor improvement to Basal's documentation (in the right place)

### DIFF
--- a/content/Basal.md
+++ b/content/Basal.md
@@ -13,7 +13,7 @@ Basal is a easy to use and nice sounding oscillator. It's specifically designed 
 
 - **Tune**: offsets the V/OCT input one octave up or down.
 - **Oct**: offsets the V/OCT input three octaves up and down.
-- **Mod 1**: creates overtones by distorting the phase of the main oscillator.
-- **Mod 2**: increases the number of harmonics.
+- **Mod 1**: creates overtones by distorting the phase of the main oscillator (-10V to +10V). The CV input is attenuverted according to the smaller encoder and then added to Mod 1.
+- **Mod 2**: increases the number of harmonics (-10V to +10V). The CV input is attenuverted according to the smaller encoder and then added to Mod 2.
 - **V/OCT**: this is the main input of the oscillator. It defines the pitch using the 1V per octave convention. Zero volts corresponds to a C3 note.
 - **Out**: main output of the oscillator.


### PR DESCRIPTION
@modlfo, thank you so much for your amazing work with Vult. Hope you don't mind if I suggest this little addition to the documentation.

I added information about the voltage represented by the Mod 1 and 2 encoders and how the CV input and related attenuverters behave. Hope I got it right from my experiments 😀